### PR TITLE
[Proposition] Different mobile UX behaviour

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,7 +10,8 @@
   <title>Palette Generator | Significa</title>
 </svelte:head>
 
-<Toaster {toaster} let:toast>
+<!-- Toast fixed while occupying screen is preventing X-axis scroll events from being triggered. -->
+<Toaster {toaster} let:toast class='overflow-visible pointer-events-none inset-auto bottom-[10px] h-1 inset-x-1'>
   <Toast {toast} />
 </Toaster>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -300,11 +300,11 @@
       </h1>
     </button>
     <div
-    class={cn(
-      'lg:p-2 lg:pl-0 pb-10 flex flex-col lg:gap-2',
-      'overflow-auto h-full lg:h-[calc(100dvh-theme(space.10)-theme(space.4))] bg-white',
-      'lg:overflow-visible overflow-scroll lg:h-full lg:bg-transparent'
-    )}
+      class={cn(
+        'lg:p-2 lg:pl-0 pb-10 flex flex-col lg:gap-2',
+        'overflow-auto h-full lg:h-[calc(100dvh-theme(space.10)-theme(space.4))] bg-white',
+        'lg:overflow-visible overflow-scroll lg:h-full lg:bg-transparent'
+      )}
     >
       {#each colors as c}
         {@const { base, palette } = generatePalette(

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -67,7 +67,7 @@
     class={cn(
       'bg-white flex flex-col gap-2 overflow-auto shadow-sm',
       'lg:w-80 lg:rounded-xl lg:border lg:m-2 lg:mr-0',
-      'pb-10 lg:pb-0' // account for the colors panel at the bottom in mobile
+      'pb-60 lg:pb-0' // account for the colors panel at the bottom in mobile
     )}
   >
     <header class="border-b px-4 py-2">
@@ -274,15 +274,16 @@
     class={cn(
       'flex-1 lg:overflow-auto',
       'fixed z-40 top-[100dvh-theme(space.6)] w-full h-full bg-white',
+      'bottom-0',
       'lg:static lg:bg-transparent lg:top-auto lg:w-auto',
       'transition-all',
-      mobileColorsPanel ? 'top-0 bg-black/10' : 'top-[calc(100dvh-theme(space.10))] bg-black/0'
+      mobileColorsPanel ? 'h-[100dvh] bg-black/10' : 'h-[calc(theme(space.60))] bg-black/0'
     )}
   >
     <button
-      on:click={() => {
-        mobileColorsPanel = !mobileColorsPanel;
-      }}
+    on:click={() => {
+      mobileColorsPanel = !mobileColorsPanel;
+    }}
       class={cn(
         'block w-full h-10 px-4 py-2 lg:hidden rounded-t-lg border bg-white transition-all',
         mobileColorsPanel ? 'mt-4' : 'mt-0',
@@ -299,11 +300,11 @@
       </h1>
     </button>
     <div
-      class={cn(
-        'lg:p-2 lg:pl-0 flex flex-col lg:gap-2',
-        'overflow-auto h-[calc(100dvh-theme(space.10)-theme(space.4))] bg-white',
-        'lg:overflow-visible lg:h-full lg:bg-transparent'
-      )}
+    class={cn(
+      'lg:p-2 lg:pl-0 pb-10 flex flex-col lg:gap-2',
+      'overflow-auto h-full lg:h-[calc(100dvh-theme(space.10)-theme(space.4))] bg-white',
+      'lg:overflow-visible overflow-scroll lg:h-full lg:bg-transparent'
+    )}
     >
       {#each colors as c}
         {@const { base, palette } = generatePalette(


### PR DESCRIPTION
Do with this PR as you wish, I just thought that it would be cool if there was a way of always visualizing the palettes 🤓

Currently, the user has no way of visualizing the palettes while changing the settings at the same time.

With this PR, I propose to change the `height` of the `palette` `drawer` to allow the user to visualize, even if slightly, the available created palettes.

https://github.com/significa/palette-generator/assets/30603437/9a73a867-eb20-4555-8f2a-6f81fdb1ff25

⚠️ I detected something _weird_ in the `Toaster` but maybe it is intended that way (if it is, the functionality of this PR doesn't work). Notice that if you remove the rules that I added to the toaster that you are not able to do horizontal scrolls unless the `drawer` is all the way up; I believe that this is due to the fact that `fixed` elements don't allow for events to bubble (why it works for vertical scrolls escapes my mind). Anyway, just a heads-up on that regard ⚠️